### PR TITLE
画像削除の方法を変更

### DIFF
--- a/server/django/memos/models.py
+++ b/server/django/memos/models.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 import uuid

--- a/server/django/memos/models.py
+++ b/server/django/memos/models.py
@@ -74,5 +74,4 @@ def generate_passkey(sender, instance, **kwargs):
 @receiver(post_delete, sender=Memo)
 def delete_image_files(sender, instance, **kwargs):
     if instance.qr_img:
-        if os.path.isfile(instance.qr_img.path):
-            os.remove(instance.qr_img.path)
+        instance.qr_img.delete(save=False)


### PR DESCRIPTION
- ```This backend doesn't support absolute paths.```というエラーが発生した
- どうやらリモートストレージでは絶対パスが使用できないらしい
- 削除方法を```os.remove()```から```FieldFile.delete()```に変更することで解決した